### PR TITLE
CardViewの追加と初期リスト読み込みがうまくいかない問題を修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     kapt 'com.google.dagger:dagger-compiler:2.27'
     kapt 'com.google.dagger:dagger-android-processor:2.27'
     implementation 'androidx.fragment:fragment-ktx:1.2.4'
+    implementation "androidx.cardview:cardview:1.0.0"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoFragment.kt
+++ b/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoFragment.kt
@@ -70,7 +70,6 @@ class RepoFragment : Fragment(), TextWatcher {
                 adapter = RepoRecyclerViewAdapter(viewModel, listener, viewLifecycleOwner)
             }
         }
-        viewModel.fetchRepos()
 
         val edit : EditText = binding.root.findViewById(R.id.serchText)
         edit.addTextChangedListener(this)

--- a/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoRecyclerViewAdapter.kt
+++ b/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoRecyclerViewAdapter.kt
@@ -1,12 +1,16 @@
 package io.github.sassy.githubrepolist.ui
 
+import android.util.Log
 import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.databinding.BindingAdapter
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
 import io.github.sassy.githubrepolist.R
 import io.github.sassy.githubrepolist.databinding.FragmentRepoBinding
 
@@ -31,6 +35,11 @@ class RepoRecyclerViewAdapter(
             // one) that an item has been selected.
             mListener?.onListFragmentInteraction(item)
         }
+
+        // これ必要？ないと更新されないが。
+        viewModel.reposFullNames.observe(parentLifecycleOwner, Observer { list ->
+            notifyDataSetChanged()
+        })
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -51,11 +60,11 @@ class RepoRecyclerViewAdapter(
     }
 
     override fun getItemCount(): Int {
-        val value = viewModel.reposFullNames.value
-        if (value == null) {
-            return 1
-        }
-        return value.size
+        return viewModel.getCount()
+    }
+
+    fun update() {
+        notifyDataSetChanged()
     }
 
     inner class ViewHolder(val binding: FragmentRepoBinding) : RecyclerView.ViewHolder(binding.root) {

--- a/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoRecyclerViewAdapter.kt
+++ b/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoRecyclerViewAdapter.kt
@@ -63,10 +63,6 @@ class RepoRecyclerViewAdapter(
         return viewModel.getCount()
     }
 
-    fun update() {
-        notifyDataSetChanged()
-    }
-
     inner class ViewHolder(val binding: FragmentRepoBinding) : RecyclerView.ViewHolder(binding.root) {
         val mContentView: TextView = binding.root.content
 

--- a/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoRecyclerViewAdapter.kt
+++ b/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoRecyclerViewAdapter.kt
@@ -1,22 +1,18 @@
 package io.github.sassy.githubrepolist.ui
 
-import android.util.Log
 import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.databinding.BindingAdapter
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import io.github.sassy.githubrepolist.R
 import io.github.sassy.githubrepolist.databinding.FragmentRepoBinding
 
 
 import io.github.sassy.githubrepolist.ui.RepoFragment.OnListFragmentInteractionListener
-import io.github.sassy.githubrepolist.vo.Repo
 
 import kotlinx.android.synthetic.main.fragment_repo.view.*
 

--- a/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoViewModel.kt
+++ b/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoViewModel.kt
@@ -9,7 +9,7 @@ import io.github.sassy.githubrepolist.vo.Repo
 import javax.inject.Inject
 
 class RepoViewModel @Inject constructor(private val repository: RepoRepository) : ViewModel() {
-    private var repos: MutableLiveData<List<Repo>> = MutableLiveData()
+    private val repos: MutableLiveData<List<Repo>> = MutableLiveData()
     private var filterText: MutableLiveData<String> = MutableLiveData()
     val reposFullNames: LiveData<List<String>> = Transformations.map(filterText, { text ->
         repos.value!!.map { repo ->

--- a/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoViewModel.kt
+++ b/app/src/main/java/io/github/sassy/githubrepolist/ui/RepoViewModel.kt
@@ -8,11 +8,9 @@ import io.github.sassy.githubrepolist.repository.RepoRepository
 import io.github.sassy.githubrepolist.vo.Repo
 import javax.inject.Inject
 
-class RepoViewModel @Inject constructor(repository: RepoRepository) : ViewModel() {
-    private val repos: MutableLiveData<List<Repo>> = MutableLiveData()
+class RepoViewModel @Inject constructor(private val repository: RepoRepository) : ViewModel() {
+    private var repos: MutableLiveData<List<Repo>> = MutableLiveData()
     private var filterText: MutableLiveData<String> = MutableLiveData()
-    private val repository = repository
-
     val reposFullNames: LiveData<List<String>> = Transformations.map(filterText, { text ->
         repos.value!!.map { repo ->
             repo.fullName
@@ -20,6 +18,10 @@ class RepoViewModel @Inject constructor(repository: RepoRepository) : ViewModel(
             if (text.isNullOrEmpty()) true else str.contains(text, true)
         }
     })
+
+    init {
+        fetchRepos()
+    }
 
     fun fetchRepos()  {
         repository.fetch().subscribe({ list ->
@@ -31,4 +33,6 @@ class RepoViewModel @Inject constructor(repository: RepoRepository) : ViewModel(
     fun searchRequest(text: String) {
         filterText.postValue(text)
     }
+
+    fun getCount() = if (reposFullNames.value == null) 1 else reposFullNames.value!!.size
 }

--- a/app/src/main/java/io/github/sassy/githubrepolist/vo/Repo.kt
+++ b/app/src/main/java/io/github/sassy/githubrepolist/vo/Repo.kt
@@ -13,11 +13,3 @@ data class Repo(
     @field:SerializedName("stargazers_count")
     val stars: Int
 )
-
-val dummpyRepo = Repo(
-    0,
-    "",
-    "",
-    "",
-    0
-)

--- a/app/src/main/res/layout/fragment_repo.xml
+++ b/app/src/main/res/layout/fragment_repo.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <data>
         <variable
             name="viewModel"
@@ -9,17 +11,25 @@
             type="Integer" />
     </data>
 <LinearLayout
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
-
-
-    <TextView
-        android:id="@+id/content"
-        android:layout_width="wrap_content"
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cardView"
+        android:layout_width="match_parent"
         android:layout_height="50dp"
-        android:layout_margin="@dimen/text_margin"
-        android:text = "@{viewModel.reposFullNames[position]}"
-        android:textAppearance="?attr/textAppearanceListItem" />
+        android:layout_gravity="center"
+        android:layout_margin="5dp"
+        app:cardCornerRadius="10dp"
+        >
+        <TextView
+            android:id="@+id/content"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_margin="@dimen/text_margin"
+            android:text = "@{viewModel.reposFullNames[position]}"
+            android:textAppearance="?attr/textAppearanceListItem" />
+    </androidx.cardview.widget.CardView>
+
 </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_repo_list.xml
+++ b/app/src/main/res/layout/fragment_repo_list.xml
@@ -10,6 +10,8 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:descendantFocusability="beforeDescendants"
+        android:focusableInTouchMode="true"
         android:orientation="vertical">
         <EditText
             android:id="@+id/serchText"


### PR DESCRIPTION
- CardView導入
- 最初のロードの時に、getItemCountが呼ばれないため、リストが１つだけ表示される現象が起きていた。そのため、notifyDataSetChanged()を呼んでListの数を反映されるようにした。
